### PR TITLE
Add ability to link to hardware repo

### DIFF
--- a/hexpansions.json
+++ b/hexpansions.json
@@ -3,5 +3,6 @@
     "unique_name": "Demo hexpansion name",
     "description": "An example hexpansion description",
     "shop_link": "https://example.com",
+    "hardware_repo": "https://example.com",
     "homepage": "https://example.com"
 }]

--- a/src/components/Hexpansion.astro
+++ b/src/components/Hexpansion.astro
@@ -5,6 +5,7 @@ const {
   homepage,
   unique_name,
   shop_link,
+  hardware_repo,
   image_url: image_url_prop,
   description,
 } = Astro.props;
@@ -41,7 +42,10 @@ const image_url = image_url_prop
         />
       )}
       <p>{description}</p>
-      {shop_link ? <a href={shop_link}>Buy</a> : null}
+      <div class="link-container">
+        {shop_link ? <a class="link" href={shop_link}>Buy</a> : null}
+        {hardware_repo ? <a class="link" href={hardware_repo}>Hardware Source</a> : null}
+      </div>
     </article>
   )
 }
@@ -62,4 +66,9 @@ const image_url = image_url_prop
   a {
     color: #aaa;
   }
+  a.link:not(:nth-child(2)) {
+    border-left: 1px solid white;
+    margin-left: .7vw !important;
+    padding-left: .7vw !important;
+}
 </style>

--- a/src/hexpansion_schema.ts
+++ b/src/hexpansion_schema.ts
@@ -7,6 +7,7 @@ export const hexpansion_description = z.object({
     homepage: z.optional(z.string()),
     description: z.string(),
     shop_link: z.optional(z.string()),
+    hardware_repo: z.optional(z.string().url()),
     image_url: z.optional(z.string()),
 })
 


### PR DESCRIPTION
Many Hexpansions are open source, so we should encourage hexpansions creators to link to the source files for their designs if they are available

<img width="651" alt="Screenshot 2024-06-05 at 19 16 32" src="https://github.com/hughrawlinson/hexpansion-registry/assets/7862359/27b35956-c634-440a-ac91-2abc85212883">

<img width="659" alt="Screenshot 2024-06-05 at 19 27 12" src="https://github.com/hughrawlinson/hexpansion-registry/assets/7862359/20dfec65-b393-43c1-9133-6f3481906d26">
